### PR TITLE
fix: portable systemd unit installation (issue #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,20 +102,23 @@ cd pidog-embodiment
 # === On the BODY (Pi 4 / Robot) ===
 cd body
 pip3 install -r requirements.txt
-# Copy your robot's control daemon (or use the included PiDog one)
-sudo cp services/nox-*.service /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable --now nox-body nox-bridge nox-voice
+# Generates the systemd units for YOUR user and repo path, creates nox.env:
+sudo ../scripts/install-body.sh
+# Edit body/nox.env (set BRAIN_HOST — 127.0.0.1 if brain and body share one machine), then:
+sudo systemctl start nox-body nox-bridge nox-voice
 
 # === On the BRAIN (Pi 5 / Desktop) ===
 cd brain
 pip3 install -r requirements.txt
-export OPENAI_API_KEY="your-key-here"
-export PIDOG_HOST="your-robot.local"  # or IP address
-sudo cp services/nox-brain.service /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable --now nox-brain
+sudo ../scripts/install-brain.sh
+# Put OPENAI_API_KEY (not needed for Ollama) and PIDOG_HOST into /etc/default/nox-brain, then:
+sudo systemctl start nox-brain
 ```
+
+> **Note:** Don't copy the `services/*.service` files verbatim — they contain a
+> reference user and paths. If you did and got
+> *"failed because of unavailable resources or another system error"*, run the
+> install script above; it rewrites `User=` and all paths for your machine.
 
 ### Test It
 

--- a/scripts/install-body.sh
+++ b/scripts/install-body.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Install the body systemd units for the *current* user and repo location.
+#
+# The unit files in body/services/ ship with a reference setup (user "pidog",
+# code in /home/pidog). Installing them verbatim on any other machine makes
+# systemd fail with the cryptic "failed because of unavailable resources or
+# another system error" (issue #5). This script rewrites User=, paths and
+# EnvironmentFile= to match the machine it runs on.
+#
+# Usage:
+#   sudo ./scripts/install-body.sh            # nox-body nox-bridge nox-voice
+#   sudo ./scripts/install-body.sh nox-vision # additionally install extra units
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Run with sudo: sudo $0 $*" >&2
+  exit 1
+fi
+
+BODY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../body" && pwd)"
+RUN_USER="${SUDO_USER:-$USER}"
+UNITS=(nox-body nox-bridge nox-voice "$@")
+
+if ! id "$RUN_USER" >/dev/null 2>&1 || [[ "$RUN_USER" == "root" ]]; then
+  echo "Could not determine the non-root user to run the services as." >&2
+  echo "Run via sudo from your normal user account." >&2
+  exit 1
+fi
+
+ENV_CREATED=0
+if [[ ! -f "$BODY_DIR/nox.env" ]]; then
+  cp "$BODY_DIR/nox.env.example" "$BODY_DIR/nox.env"
+  chown "$RUN_USER": "$BODY_DIR/nox.env"
+  ENV_CREATED=1
+fi
+
+for unit in "${UNITS[@]}"; do
+  src="$BODY_DIR/services/${unit}.service"
+  if [[ ! -f "$src" ]]; then
+    echo "Unknown unit: $unit (no $src)" >&2
+    exit 1
+  fi
+  sed -e "s|^User=.*|User=${RUN_USER}|" \
+      -e "s|/home/pidog|${BODY_DIR}|g" \
+      "$src" > "/etc/systemd/system/${unit}.service"
+  echo "Installed /etc/systemd/system/${unit}.service (User=${RUN_USER}, dir=${BODY_DIR})"
+done
+
+systemctl daemon-reload
+systemctl enable "${UNITS[@]}"
+
+if [[ $ENV_CREATED -eq 1 ]]; then
+  echo
+  echo "Created $BODY_DIR/nox.env from the example."
+  echo "Edit it (at least BRAIN_HOST — use 127.0.0.1 if brain and body share one machine), then:"
+  echo "  sudo systemctl start ${UNITS[*]}"
+else
+  systemctl restart "${UNITS[@]}"
+  echo
+  echo "Services restarted. Check with: systemctl status ${UNITS[*]}"
+fi

--- a/scripts/install-brain.sh
+++ b/scripts/install-brain.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Install the brain systemd unit for the *current* user and repo location.
+# Same rationale as install-body.sh: the shipped unit hardcodes a reference
+# user and path, which breaks on any other machine (issue #5).
+#
+# Usage: sudo ./scripts/install-brain.sh
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Run with sudo: sudo $0" >&2
+  exit 1
+fi
+
+BRAIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../brain" && pwd)"
+RUN_USER="${SUDO_USER:-$USER}"
+
+if ! id "$RUN_USER" >/dev/null 2>&1 || [[ "$RUN_USER" == "root" ]]; then
+  echo "Could not determine the non-root user to run the service as." >&2
+  echo "Run via sudo from your normal user account." >&2
+  exit 1
+fi
+
+sed -e "s|^User=.*|User=${RUN_USER}|" \
+    -e "s|^WorkingDirectory=.*|WorkingDirectory=${BRAIN_DIR}|" \
+    "$BRAIN_DIR/services/nox-brain.service" > /etc/systemd/system/nox-brain.service
+echo "Installed /etc/systemd/system/nox-brain.service (User=${RUN_USER}, dir=${BRAIN_DIR})"
+
+systemctl daemon-reload
+systemctl enable nox-brain
+
+echo
+echo "Set your API key and robot address in /etc/default/nox-brain, e.g.:"
+echo "  OPENAI_API_KEY=your-key        # only needed for OpenAI-compatible APIs, not Ollama"
+echo "  PIDOG_HOST=your-robot.local"
+echo "then: sudo systemctl start nox-brain"


### PR DESCRIPTION
## Problem

The unit files in `body/services/` and `brain/services/` hardcode the reference setup: `User=pidog` / `User=piclawbot` and absolute `/home/pidog` paths. Anyone following the README quickstart (`sudo cp services/*.service`) on a machine without those users hits systemd's cryptic:

> Job for nox-body.service failed because of unavailable resources or another system error.

First external installer ran straight into this: #5.

## Fix

- **`scripts/install-body.sh`** — generates `nox-body`/`nox-bridge`/`nox-voice` units (extra units like `nox-vision` via args) with the invoking user and actual repo path, creates `body/nox.env` from the example on first run, enables the units. Only starts/restarts services once `nox.env` exists, so first-time users get a chance to set `BRAIN_HOST` first.
- **`scripts/install-brain.sh`** — same for `nox-brain.service` (config stays in `/etc/default/nox-brain`).
- **README** — quickstart now uses the install scripts; added a troubleshooting note mapping the systemd error message to this cause.

The shipped unit files are unchanged, so the reference PiDog setup keeps working.

## Test

`bash -n` on both scripts; sed transformation verified against `nox-body.service` (User/WorkingDirectory/ExecStart/EnvironmentFile all rewritten correctly for a `cat1` user). Not yet run on a fresh Linux box — issue #5's reporter is effectively the field test.

Closes #5 (together with the workaround posted there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)