### PR TITLE
feat(brain): configurable LLM endpoint (Ollama) + auto-create /etc/default/nox-brain

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,11 @@ sudo systemctl start nox-body nox-bridge nox-voice
 # === On the BRAIN (Pi 5 / Desktop) ===
 cd brain
 pip3 install -r requirements.txt
+# Generates the systemd unit for YOUR user/path and creates /etc/default/nox-brain:
 sudo ../scripts/install-brain.sh
-# Put OPENAI_API_KEY (not needed for Ollama) and PIDOG_HOST into /etc/default/nox-brain, then:
+# Edit /etc/default/nox-brain: set PIDOG_HOST (127.0.0.1 if brain and body share
+# one machine) and the LLM backend — OPENAI_API_KEY for OpenAI, or for a local
+# Ollama: OPENAI_URL=http://127.0.0.1:11434/v1/chat/completions + LLM_MODEL=llama3.2
 sudo systemctl start nox-brain
 ```
 

--- a/brain/nox_voice_brain.py
+++ b/brain/nox_voice_brain.py
@@ -28,8 +28,12 @@ BRIDGE_PORT = int(os.environ.get("PIDOG_BRIDGE_PORT", "8888"))
 BASE_URL = f"http://{PIDOG_HOST}:{BRIDGE_PORT}"
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
-OPENAI_MODEL = "gpt-4o"  # Better accuracy for structured JSON voice responses
-OPENAI_URL = "https://api.openai.com/v1/chat/completions"
+# Any OpenAI-compatible chat-completions endpoint works. For a local Ollama:
+#   OPENAI_URL=http://127.0.0.1:11434/v1/chat/completions  LLM_MODEL=llama3.2
+# api.openai.com requires OPENAI_API_KEY; local endpoints don't.
+OPENAI_MODEL = os.environ.get("LLM_MODEL", "gpt-4o")  # gpt-4o: better accuracy for structured JSON voice responses
+OPENAI_URL = os.environ.get("OPENAI_URL", "https://api.openai.com/v1/chat/completions")
+LLM_CONFIGURED = bool(OPENAI_API_KEY) or "api.openai.com" not in OPENAI_URL
 
 POLL_INTERVAL = 5.0  # Slow poll; push handles real-time
 SENSOR_CHECK_INTERVAL = 15.0
@@ -147,7 +151,7 @@ def bridge_post(path, data, timeout=15):
 # ─── Claude API ───
 def call_llm(messages, system=SYSTEM_PROMPT, max_tokens=256):
     """Call OpenAI-compatible API for voice response."""
-    if not OPENAI_API_KEY:
+    if not LLM_CONFIGURED:
         return None
     
     # OpenAI format: system message is part of messages
@@ -164,7 +168,8 @@ def call_llm(messages, system=SYSTEM_PROMPT, max_tokens=256):
     body = json.dumps(data).encode()
     req = urllib.request.Request(OPENAI_URL, data=body, method="POST")
     req.add_header("Content-Type", "application/json")
-    req.add_header("Authorization", f"Bearer {OPENAI_API_KEY}")
+    if OPENAI_API_KEY:
+        req.add_header("Authorization", f"Bearer {OPENAI_API_KEY}")
     
     try:
         with urllib.request.urlopen(req, timeout=25) as resp:
@@ -368,12 +373,12 @@ def main():
     import threading as _th
     _th.Thread(target=start_push_server, daemon=True).start()
 
-    has_api = bool(OPENAI_API_KEY)
+    has_api = LLM_CONFIGURED
     if has_api:
-        print(f"[brain] LLM API available (model: {OPENAI_MODEL})", flush=True)
+        print(f"[brain] LLM API available (model: {OPENAI_MODEL}, url: {OPENAI_URL})", flush=True)
         process_fn = process_voice_intelligent
     else:
-        print("[brain] No API key — using simple fallback", flush=True)
+        print("[brain] No LLM configured (set OPENAI_API_KEY, or OPENAI_URL for a local endpoint) — using simple fallback", flush=True)
         process_fn = process_voice_simple
     
     last_sensor_check = 0

--- a/brain/services/nox-brain.service
+++ b/brain/services/nox-brain.service
@@ -11,10 +11,11 @@ ExecStart=/usr/bin/python3 -u nox_voice_brain.py
 Restart=on-failure
 RestartSec=5
 Environment=PYTHONUNBUFFERED=1
-# Set these in /etc/default/nox-brain or override:
-# Environment=OPENAI_API_KEY=your-key
+# Set these in /etc/default/nox-brain (install-brain.sh creates a template):
 # Environment=PIDOG_HOST=pidog.local
-# Environment=LLM_MODEL=gpt-4o-mini
+# Environment=OPENAI_API_KEY=your-key   # cloud only; not needed for Ollama
+# Environment=OPENAI_URL=http://127.0.0.1:11434/v1/chat/completions
+# Environment=LLM_MODEL=llama3.2
 EnvironmentFile=-/etc/default/nox-brain
 
 [Install]

--- a/scripts/install-brain.sh
+++ b/scripts/install-brain.sh
@@ -28,8 +28,29 @@ echo "Installed /etc/systemd/system/nox-brain.service (User=${RUN_USER}, dir=${B
 systemctl daemon-reload
 systemctl enable nox-brain
 
+# The unit reads /etc/default/nox-brain (optional). Create a commented
+# template on first install so users don't have to guess the keys (issue #5).
+if [[ ! -f /etc/default/nox-brain ]]; then
+  cat > /etc/default/nox-brain <<'EOF'
+# Nox Brain configuration — read by nox-brain.service on start.
+# Uncomment and adjust what you need, then: sudo systemctl restart nox-brain
+
+# Where the robot body's bridge runs (127.0.0.1 if brain and body share one machine):
+#PIDOG_HOST=pidog.local
+
+# LLM backend — any OpenAI-compatible chat-completions endpoint.
+# Cloud (OpenAI): set the key, keep the default URL/model:
+#OPENAI_API_KEY=sk-...
+# Local (Ollama): no key needed, point at Ollama and pick your model:
+#OPENAI_URL=http://127.0.0.1:11434/v1/chat/completions
+#LLM_MODEL=llama3.2
+EOF
+  chmod 600 /etc/default/nox-brain
+  echo "Created /etc/default/nox-brain (template — edit it, then start the service)"
+else
+  echo "Kept existing /etc/default/nox-brain"
+fi
+
 echo
-echo "Set your API key and robot address in /etc/default/nox-brain, e.g.:"
-echo "  OPENAI_API_KEY=your-key        # only needed for OpenAI-compatible APIs, not Ollama"
-echo "  PIDOG_HOST=your-robot.local"
+echo "Edit /etc/default/nox-brain (robot address + LLM backend),"
 echo "then: sudo systemctl start nox-brain"


### PR DESCRIPTION
## What

Two gaps surfaced by #5 (Thio007 running brain+body on one Linux Mint machine with Ollama):

1. **`/etc/default/nox-brain` never existed** — the unit references it optionally and `install-brain.sh` only *told* users to populate it. The script now creates a commented template on first install (mirrors how `install-body.sh` creates `nox.env`).
2. **Ollama was documented but not actually supported** — `nox_voice_brain.py` hardcoded `api.openai.com` and `gpt-4o`, and bailed out without an API key. `OPENAI_URL` and `LLM_MODEL` are now env-configurable; local endpoints need no key.

## Test

- `pytest tests/` green (6 passed)
- `OPENAI_URL=http://127.0.0.1:11434/v1/chat/completions LLM_MODEL=llama3.2` → `LLM_CONFIGURED=True` without key; default (no env) still requires `OPENAI_API_KEY`
- `bash -n scripts/install-brain.sh` clean

Refs #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)