### PR TITLE
fix(body): portable home paths — nox-bridge crash-loop on non-'pidog' users

### DIFF
--- a/body/nox_brain_bridge.py
+++ b/body/nox_brain_bridge.py
@@ -25,11 +25,14 @@ import signal
 # Behavior engine reference (set in main())
 _behavior_engine = None
 
-# Memory integration
+# Memory integration. Catch Exception, not just ImportError: the module runs
+# filesystem setup at import time, and e.g. a PermissionError from that must
+# degrade to "no memory", not kill the bridge (issue #5).
 try:
     import pidog_memory
     _HAS_MEMORY = True
-except ImportError:
+except Exception as _e:
+    print(f"[bridge] pidog_memory unavailable ({_e}) — running without memory", flush=True)
     _HAS_MEMORY = False
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from socketserver import ThreadingMixIn
@@ -45,12 +48,16 @@ DAEMON_PORT = 9999
 BRAIN_HOST = os.environ.get("BRAIN_HOST", "192.168.1.18")
 BRAIN_CALLBACK_PORT = int(os.environ.get("BRAIN_CALLBACK_PORT", "8889"))
 PHOTO_DIR = "/tmp"
-FACE_DB_DIR = "/home/pidog/nox_face_db"
+HOME_DIR = os.path.expanduser("~")
+FACE_DB_DIR = os.environ.get("NOX_FACE_DB_DIR", os.path.join(HOME_DIR, "nox_face_db"))
 PERCEPTION_INTERVAL = 2.0  # seconds between auto-perception cycles
 VISION_RESULT_FILE = "/tmp/nox_vision_latest.json"
 
-# Ensure directories exist
-os.makedirs(FACE_DB_DIR, exist_ok=True)
+# Ensure directories exist — degrade instead of dying if the path is unwritable
+try:
+    os.makedirs(FACE_DB_DIR, exist_ok=True)
+except OSError as _e:
+    print(f"[bridge] WARNING: cannot create {FACE_DB_DIR}: {_e} — face DB disabled", flush=True)
 
 # ─── Sprint 4: Expression + Movement Constants ───
 EXPRESSION_MAP = {
@@ -216,8 +223,8 @@ def get_face_engine():
         try:
             from nox_face_recognition import FaceEngine
             _face_engine = FaceEngine(
-                model_dir="/home/pidog/models",
-                db_dir="/home/pidog/face_db"
+                model_dir=os.path.join(HOME_DIR, "models"),
+                db_dir=os.path.join(HOME_DIR, "face_db")
             )
             print("[bridge] SCRFD+ArcFace face engine loaded", flush=True)
         except Exception as e:

--- a/body/nox_control.py
+++ b/body/nox_control.py
@@ -29,10 +29,10 @@ import time
 import subprocess
 import json
 
-PIDOG_DIR = "/home/pidog/pidog"
+PIDOG_DIR = os.path.expanduser("~/pidog")
 SOUNDS_DIR = os.path.join(PIDOG_DIR, "sounds")
-PIPER_BIN = "/home/pidog/.local/bin/piper"
-PIPER_MODEL = "/home/pidog/.local/share/piper-voices/de_DE-thorsten-high.onnx"
+PIPER_BIN = os.path.expanduser("~/.local/bin/piper")
+PIPER_MODEL = os.path.expanduser("~/.local/share/piper-voices/de_DE-thorsten-high.onnx")
 
 sys.path.insert(0, os.path.join(PIDOG_DIR, "gpt_examples"))
 

--- a/body/nox_daemon.py
+++ b/body/nox_daemon.py
@@ -40,9 +40,9 @@ os.environ["AUDIODEV"] = _PLAYBACK_DEVICE
 
 SOCKET_PATH = "/tmp/nox.sock"
 PHOTO_DIR = "/tmp"
-PIPER_BIN = "/home/pidog/.local/bin/piper"
-PIPER_MODEL = "/home/pidog/.local/share/piper-voices/de_DE-thorsten-high.onnx"
-SOUNDS_DIR = "/home/pidog/pidog/sounds"
+PIPER_BIN = os.path.expanduser("~/.local/bin/piper")
+PIPER_MODEL = os.path.expanduser("~/.local/share/piper-voices/de_DE-thorsten-high.onnx")
+SOUNDS_DIR = os.path.expanduser("~/pidog/sounds")
 
 # ─── Ultrasonic distance sensor (separate from PiDog to avoid Process hang) ───
 ultrasonic = None

--- a/body/nox_vision.py
+++ b/body/nox_vision.py
@@ -27,11 +27,11 @@ import signal
 
 # llama.cpp binary — try mtmd first (newer), fallback to llava
 _LLAMA_BINS = [
-    "/home/pidog/llama.cpp/build/bin/llama-mtmd-cli",
-    "/home/pidog/llama.cpp/build/bin/llama-llava-cli",
+    os.path.expanduser("~/llama.cpp/build/bin/llama-mtmd-cli"),
+    os.path.expanduser("~/llama.cpp/build/bin/llama-llava-cli"),
 ]
-MODEL_PATH = "/home/pidog/models/smolvlm/SmolVLM-256M-Instruct-Q8_0.gguf"
-MMPROJ_PATH = "/home/pidog/models/smolvlm/mmproj-SmolVLM-256M-Instruct-Q8_0.gguf"
+MODEL_PATH = os.path.expanduser("~/models/smolvlm/SmolVLM-256M-Instruct-Q8_0.gguf")
+MMPROJ_PATH = os.path.expanduser("~/models/smolvlm/mmproj-SmolVLM-256M-Instruct-Q8_0.gguf")
 RESULT_FILE = "/tmp/nox_vision_latest.json"
 PHOTO_PATH = "/tmp/nox_vision_frame.jpg"
 

--- a/body/nox_voice_loop.py
+++ b/body/nox_voice_loop.py
@@ -21,9 +21,12 @@ os.environ["SDL_AUDIODRIVER"] = "alsa"
 os.environ["AUDIODEV"] = "plughw:3,0"
 
 # ─── Config ───
-VOSK_MODEL_PATH = "/home/pidog/vosk-models/vosk-model-small-de-0.15"
-PIPER_BIN = "/home/pidog/.local/bin/piper"
-PIPER_MODEL = "/home/pidog/.local/share/piper-voices/de_DE-thorsten-high.onnx"
+VOSK_MODEL_PATH = os.environ.get(
+    "VOSK_MODEL_PATH",
+    os.path.expanduser("~/vosk-models/vosk-model-small-de-0.15"),
+)
+PIPER_BIN = os.path.expanduser("~/.local/bin/piper")
+PIPER_MODEL = os.path.expanduser("~/.local/share/piper-voices/de_DE-thorsten-high.onnx")
 NOX_DAEMON_HOST = "localhost"
 NOX_DAEMON_PORT = 9999
 CLAWDBOT_HOST = os.environ.get("CLAWDBOT_HOST", "192.168.1.18")

--- a/body/nox_voice_loop_v2.py
+++ b/body/nox_voice_loop_v2.py
@@ -29,7 +29,10 @@ import urllib.request
 os.environ["SDL_AUDIODRIVER"] = "alsa"
 
 # ─── Config ───
-VOSK_MODEL_PATH = "/home/pidog/vosk-models/vosk-model-small-de-0.15"
+VOSK_MODEL_PATH = os.environ.get(
+    "VOSK_MODEL_PATH",
+    os.path.expanduser("~/vosk-models/vosk-model-small-de-0.15"),
+)
 BRIDGE_HOST = "localhost"
 BRIDGE_PORT = 8888
 DAEMON_HOST = "localhost"
@@ -263,6 +266,14 @@ def main():
     print("[voice-v2] Starting Nox voice loop v2.2 (fuzzy wake words + energy gate)...", flush=True)
 
     from vosk import Model, KaldiRecognizer
+
+    if not os.path.isdir(VOSK_MODEL_PATH):
+        # Exit 0 on purpose: Restart=on-failure would otherwise crash-loop the
+        # service on every machine that hasn't downloaded a model yet.
+        print(f"[voice-v2] Vosk model not found: {VOSK_MODEL_PATH}", flush=True)
+        print("[voice-v2] Download one from https://alphacephei.com/vosk/models and unzip it there,", flush=True)
+        print("[voice-v2] or set VOSK_MODEL_PATH in nox.env. Voice input stays off until then.", flush=True)
+        sys.exit(0)
 
     print(f"[voice-v2] Loading Vosk model: {VOSK_MODEL_PATH}", flush=True)
     model = Model(VOSK_MODEL_PATH)

--- a/body/pidog_memory.py
+++ b/body/pidog_memory.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Optional, List, Dict
 
 # === Configuration ===
-MEMORY_ROOT = Path(os.environ.get("PIDOG_MEMORY_DIR", "/home/pidog/memory"))
+MEMORY_ROOT = Path(os.environ.get("PIDOG_MEMORY_DIR", str(Path.home() / "memory")))
 ACTIVE_DIR = MEMORY_ROOT / "active"
 CORE_DIR = MEMORY_ROOT / "core"
 SESSION_FILE = MEMORY_ROOT / ".session_state.json"
@@ -38,9 +38,13 @@ _last_store_time = 0
 MIN_STORE_INTERVAL = 60           # seconds between regular stores
 HIGH_PRIORITY_TAGS = {"touch", "person", "social", "face", "battery_low"}
 
-# Create directories
-ACTIVE_DIR.mkdir(parents=True, exist_ok=True)
-CORE_DIR.mkdir(parents=True, exist_ok=True)
+# Create directories. Never crash the importer over this — a bridge without
+# memory is degraded, a bridge that dies at import is dead (issue #5).
+try:
+    ACTIVE_DIR.mkdir(parents=True, exist_ok=True)
+    CORE_DIR.mkdir(parents=True, exist_ok=True)
+except OSError as _e:
+    print(f"[memory] WARNING: cannot create {MEMORY_ROOT}: {_e} — memory storage unavailable", flush=True)
 
 # Session state
 _session_retrieved: set = set()


### PR DESCRIPTION
Fixes the crash-loop @Thio007 hit in #5: `nox-bridge` exited with status 1 ~150ms after start on any machine whose service user isn't `pidog`.

**Root cause (two import-time crashes):**
1. `pidog_memory.py` ran `mkdir /home/pidog/memory` at import → `PermissionError` for other users. The bridge's `except ImportError` never matched a `PermissionError`, so the exception killed the process.
2. `nox_brain_bridge.py` ran `os.makedirs('/home/pidog/nox_face_db')` unguarded at module level.

**Changes:**
- All user paths derived from the service user's home via `expanduser` — on the reference robot (user `pidog`) the resolved paths are byte-identical, so no behavior change there.
- Import-time `mkdir` calls guarded: warn + degrade instead of dying.
- Bridge memory import guard catches `Exception`, not just `ImportError`.
- Voice loops: `VOSK_MODEL_PATH` env-overridable; v2 exits cleanly (code 0) with download instructions when no Vosk model is installed, instead of systemd-crash-looping.

**Verified:** `py_compile` on all 7 files, test suite green (6 passed), and simulated the issue-#5 scenario: import with unwritable memory dir → warning + clean import; bridge import under a sandboxed $HOME → dirs created in the correct home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)