### PR TITLE
fix(body): /speak fails loudly when the piper voice is missing; configurable TTS + audio device

### DIFF
--- a/body/nox_daemon.py
+++ b/body/nox_daemon.py
@@ -35,13 +35,22 @@ def _find_hifiberry_card():
     print("[nox] HifiBerry not found, falling back to plughw:3,0", flush=True)
     return "plughw:3,0"
 
-_PLAYBACK_DEVICE = _find_hifiberry_card()
+# nox.env may pin AUDIODEV for robots whose speaker isn't auto-detectable
+_PLAYBACK_DEVICE = os.environ.get("AUDIODEV") or _find_hifiberry_card()
 os.environ["AUDIODEV"] = _PLAYBACK_DEVICE
 
 SOCKET_PATH = "/tmp/nox.sock"
 PHOTO_DIR = "/tmp"
-PIPER_BIN = os.path.expanduser("~/.local/bin/piper")
-PIPER_MODEL = os.path.expanduser("~/.local/share/piper-voices/de_DE-thorsten-high.onnx")
+def _find_piper():
+    """pip installs the piper CLI to ~/.local/bin OR /usr/local/bin depending on how it was run."""
+    local = os.path.expanduser("~/.local/bin/piper")
+    if os.path.exists(local):
+        return local
+    import shutil
+    return shutil.which("piper") or local
+
+PIPER_BIN = os.environ.get("PIPER_BIN") or _find_piper()
+PIPER_MODEL = os.environ.get("PIPER_MODEL") or os.path.expanduser("~/.local/share/piper-voices/de_DE-thorsten-high.onnx")
 SOUNDS_DIR = os.path.expanduser("~/pidog/sounds")
 
 # ─── Ultrasonic distance sensor (separate from PiDog to avoid Process hang) ───
@@ -361,6 +370,18 @@ def cmd_speak(text):
     # Guard: empty or whitespace-only text crashes Piper
     if not text or not text.strip():
         return {"ok": False, "error": "empty text"}
+    # Fail loudly instead of returning ok while the async pipeline dies (issue #5):
+    # piper voice models are NOT installed by pip — the user must download one.
+    if not os.path.exists(PIPER_MODEL):
+        return {"ok": False, "error": (
+            f"piper voice model not found: {PIPER_MODEL} — download a voice from "
+            "https://huggingface.co/rhasspy/piper-voices and set PIPER_MODEL in nox.env"
+        )}
+    if not os.path.exists(PIPER_BIN):
+        return {"ok": False, "error": (
+            f"piper binary not found: {PIPER_BIN} — pip3 install piper-tts, "
+            "or set PIPER_BIN in nox.env"
+        )}
 
     def _tts_pipeline(speak_text):
         import subprocess as sp

--- a/body/services/nox-body.service
+++ b/body/services/nox-body.service
@@ -13,7 +13,8 @@ RestartSec=5
 Environment=PATH=/home/pidog/.local/bin:/usr/local/bin:/usr/bin:/bin
 Environment=PYTHONUNBUFFERED=1
 Environment=SDL_AUDIODRIVER=alsa
-Environment=AUDIODEV=plughw:3,0
+# AUDIODEV intentionally not set here: the daemon auto-detects the speaker;
+# pin it in nox.env instead if detection picks the wrong card.
 
 [Install]
 WantedBy=multi-user.target

--- a/body/services/nox-voice.service
+++ b/body/services/nox-voice.service
@@ -14,7 +14,7 @@ RestartSec=10
 Environment=PATH=/home/pidog/.local/bin:/usr/local/bin:/usr/bin:/bin
 Environment=PYTHONUNBUFFERED=1
 Environment=SDL_AUDIODRIVER=alsa
-Environment=AUDIODEV=plughw:3,0
+# AUDIODEV intentionally not set: the voice loop auto-detects the USB mic.
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Follow-up to @Thio007's no-sound report in #5: `POST /speak` returned ok while the async TTS pipeline failed in the background.

**Root cause:** piper voice models are not shipped by `pip install piper-tts` — the daemon pointed at the reference robot's `de_DE-thorsten-high.onnx` and logged the failure instead of reporting it. The piper binary path (`~/.local/bin`) and ALSA playback device (`plughw:3,0`, hardcoded in the unit files) were also reference-robot-specific.

**Changes:**
- `cmd_speak` validates `PIPER_MODEL`/`PIPER_BIN` up front → `/speak` now returns `{ok: false, error: "piper voice model not found: ... download from https://huggingface.co/rhasspy/piper-voices"}` instead of a silent ok
- piper CLI resolved via `~/.local/bin` then `PATH` (pip installs to either)
- `PIPER_BIN`, `PIPER_MODEL`, `AUDIODEV` overridable via `nox.env`; shipped units no longer pin `AUDIODEV=plughw:3,0`

**Verified:** `py_compile`, test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)