### PR TITLE
fix(bridge): /action accepts singular {"action": "sit"}, errors loudly on empty input

### DIFF
--- a/body/nox_brain_bridge.py
+++ b/body/nox_brain_bridge.py
@@ -569,8 +569,22 @@ class BridgeHandler(BaseHTTPRequestHandler):
         body = self._read_json()
         
         if path == "/action":
-            # Execute body action(s)
-            actions = body.get("actions", [])
+            # Execute body action(s). Accept both {"actions": [...]} (array) and
+            # the singular {"action": "sit"} — the latter is what people reach for
+            # first, and silently returning ok with no movement is a footgun.
+            actions = body.get("actions")
+            if actions is None and "action" in body:
+                actions = [body["action"]]
+            if not actions:
+                self._send_json({
+                    "ok": False,
+                    "error": "no action given",
+                    "hint": 'send {"action": "sit"} or {"actions": ["sit", "wag_tail"]}',
+                    "valid_actions": VALID_ACTIONS,
+                })
+                return
+            if isinstance(actions, str):
+                actions = [actions]
             results = []
             for action in actions:
                 if isinstance(action, str):
@@ -580,7 +594,8 @@ class BridgeHandler(BaseHTTPRequestHandler):
                 else:
                     r = {"error": f"invalid action: {action}"}
                 results.append(r)
-            self._send_json({"ok": True, "results": results})
+            ok = all(not (isinstance(r, dict) and r.get("error")) for r in results)
+            self._send_json({"ok": ok, "results": results})
         
         elif path == "/speak":
             # Speak text (non-blocking: respond immediately, speak in background)


### PR DESCRIPTION
Follow-up to @Thio007 in #12: `POST /action -d '{"action": "sit"}'` returned `{"ok": true, "results": []}` and the dog didn't move.

**Root cause:** the handler only read the plural `body.get("actions", [])` array. A singular `{"action": "sit"}` matched nothing, the loop never ran, and it reported success with an empty result set — a silent footgun.

**Changes:**
- accept singular `"action"` (string) in addition to plural `"actions"` (array)
- when neither is present, return `{ok: false, error, hint, valid_actions}` instead of a silent ok
- `ok` now reflects per-action daemon errors instead of always being true

**Verified:** `py_compile`, test suite green (6 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)