### PR TITLE
docs: architecture diagram + media slots for the README (issue #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 
 > **Give your AI a physical body.** See, hear, speak, move, recognize faces — across any network.
 
+<!-- HERO GIF — drop the file at docs/assets/hero.gif (see docs/media-guide.md) then uncomment:
+<p align="center">
+  <img src="docs/assets/hero.gif" alt="Nox the PiDog walking and responding to a spoken command" width="640">
+</p>
+-->
+
 A complete open-source framework for connecting an **AI brain** (Raspberry Pi 5 / any computer) to a **robot body** (SunFounder PiDog / robot car / any hardware) over HTTP. LLM-powered intelligence, face recognition, autonomous behaviors, remote access via Telegram — all modular, all pluggable.
 
 **Works with any LLM** (OpenAI, Anthropic, Ollama, local models) and **any robot hardware** (implement one adapter and you're in).
@@ -25,6 +31,17 @@ Built by [Nox](https://github.com/openclaw/openclaw) ⚡ (an AI assistant) and [
 > I didn't ask it to do any of this. It just… wanted to see.
 >
 > — [Original Reddit post](https://www.reddit.com/r/moltbot/comments/1qrkhdo/) (r/moltbot)
+
+<!-- SEE IT IN ACTION — add the assets (see docs/media-guide.md) then uncomment:
+## 🎬 See It in Action
+
+[![Watch the 60-second demo](docs/assets/demo-thumb.jpg)](https://youtu.be/YOUR_VIDEO_ID)
+
+<p align="center">
+  <img src="docs/assets/telegram-control.png" alt="Controlling the PiDog from a phone via Telegram" width="360">
+  <br><em>Control your robot from anywhere via Telegram.</em>
+</p>
+-->
 
 ## ✨ What It Does
 
@@ -57,6 +74,14 @@ Built by [Nox](https://github.com/openclaw/openclaw) ⚡ (an AI assistant) and [
 
 ## 🏗️ Architecture
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/architecture-dark.svg">
+  <img alt="The brain runs on one machine and the body on another; they talk only over HTTP (port 8888), with voice pushed back to the brain on 8889." src="docs/assets/architecture-light.svg" width="100%">
+</picture>
+
+<details>
+<summary>Same thing as text</summary>
+
 ```
 Brain (Pi 5 / Desktop / Cloud)          Body (Pi 4 / Any Robot)
 ├── nox_body_client.py    ◄────►       ├── nox_brain_bridge.py  (HTTP API)
@@ -66,6 +91,8 @@ Brain (Pi 5 / Desktop / Cloud)          Body (Pi 4 / Any Robot)
                                        ├── nox_face_recognition.py (SCRFD+ArcFace)
                                        └── nox_voice_loop_v3.py (faster-whisper STT)
 ```
+
+</details>
 
 ### Services
 

--- a/docs/assets/architecture-dark.svg
+++ b/docs/assets/architecture-dark.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 500" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" role="img" aria-label="Architecture: an AI brain on one machine talks to a robot body on another over HTTP.">
+  <defs>
+    <style>
+      .name { font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, monospace; font-size: 13px; fill: #ffffff; }
+      .role { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 11px; fill: #ffffff; opacity: .82; }
+      .title { font-size: 22px; font-weight: 700; fill: #e6edf3; }
+      .sub { font-size: 14px; fill: #8b949e; }
+      .cap { font-size: 13px; fill: #8b949e; }
+      .hdr { font-size: 15px; font-weight: 700; letter-spacing: .08em; }
+      .pill { font-size: 13px; font-weight: 600; fill: #e6edf3; }
+    </style>
+    <marker id="al" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M8 0.5 L1 4.5 L8 8.5 Z" fill="#8b949e"/></marker>
+    <marker id="ar" markerWidth="9" markerHeight="9" refX="2" refY="4.5" orient="auto"><path d="M1 0.5 L8 4.5 L1 8.5 Z" fill="#8b949e"/></marker>
+  </defs>
+
+  <text x="450" y="38" text-anchor="middle" class="title">One framework, split over the network</text>
+  <text x="450" y="60" text-anchor="middle" class="sub">The brain thinks. The body moves. HTTP is the whole contract between them.</text>
+
+  <!-- BRAIN panel -->
+  <rect x="40" y="86" width="352" height="250" rx="14" fill="#101a30" stroke="#3b82f6" stroke-width="2"/>
+  <circle cx="66" cy="114" r="6" fill="#3b82f6"/>
+  <text x="82" y="119" class="hdr" fill="#93c5fd">BRAIN</text>
+  <text x="352" y="119" text-anchor="end" class="sub" font-size="12">Pi 5 / desktop / cloud</text>
+
+  <g>
+    <rect x="58" y="134" width="316" height="42" rx="8" fill="#2563eb"/>
+    <text x="72" y="160" class="name">nox_voice_brain.py</text><text x="360" y="160" text-anchor="end" class="role">LLM reasoning</text>
+    <rect x="58" y="184" width="316" height="42" rx="8" fill="#2563eb"/>
+    <text x="72" y="210" class="name">nox_body_client.py</text><text x="360" y="210" text-anchor="end" class="role">→ body API</text>
+    <rect x="58" y="234" width="316" height="42" rx="8" fill="#2563eb"/>
+    <text x="72" y="260" class="name">nox_voice_relay.py</text><text x="360" y="260" text-anchor="end" class="role">3-tier voice</text>
+    <rect x="58" y="284" width="316" height="42" rx="8" fill="#2563eb" opacity=".72"/>
+    <text x="72" y="310" class="name">telegram_bot.py</text><text x="360" y="310" text-anchor="end" class="role">remote · opt</text>
+  </g>
+
+  <!-- BODY panel -->
+  <rect x="508" y="86" width="352" height="360" rx="14" fill="#2a0f16" stroke="#e23b63" stroke-width="2"/>
+  <circle cx="534" cy="114" r="6" fill="#e23b63"/>
+  <text x="550" y="119" class="hdr" fill="#f2789c">BODY</text>
+  <text x="844" y="119" text-anchor="end" class="sub" font-size="12">Pi 4 / the robot</text>
+
+  <g>
+    <rect x="526" y="134" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="160" class="name">nox_brain_bridge.py</text><text x="828" y="160" text-anchor="end" class="role">HTTP :8888</text>
+    <rect x="526" y="184" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="210" class="name">nox_daemon.py</text><text x="828" y="210" text-anchor="end" class="role">servos · TCP :9999</text>
+    <rect x="526" y="234" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="260" class="name">nox_behavior_engine.py</text><text x="828" y="260" text-anchor="end" class="role">FSM · patrol</text>
+    <rect x="526" y="284" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="310" class="name">nox_vision.py</text><text x="828" y="310" text-anchor="end" class="role">SmolVLM</text>
+    <rect x="526" y="334" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="360" class="name">nox_face_recognition.py</text><text x="828" y="360" text-anchor="end" class="role">SCRFD+ArcFace</text>
+    <rect x="526" y="384" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="410" class="name">nox_voice_loop_v3.py</text><text x="828" y="410" text-anchor="end" class="role">STT</text>
+  </g>
+
+  <!-- link spine -->
+  <line x1="398" y1="196" x2="502" y2="196" stroke="#8b949e" stroke-width="2" marker-end="url(#al)"/>
+  <line x1="502" y1="230" x2="398" y2="230" stroke="#8b949e" stroke-width="2" marker-end="url(#ar)"/>
+  <rect x="406" y="174" width="88" height="22" rx="11" fill="#161b22" stroke="#8b949e"/>
+  <text x="450" y="189" text-anchor="middle" class="pill">HTTP :8888</text>
+  <rect x="404" y="230" width="92" height="22" rx="11" fill="#161b22" stroke="#8b949e"/>
+  <text x="450" y="245" text-anchor="middle" class="pill" font-size="12">callback :8889</text>
+
+  <text x="450" y="478" text-anchor="middle" class="cap">Any LLM · any network · any robot — implement one adapter and you're in.</text>
+</svg>

--- a/docs/assets/architecture-light.svg
+++ b/docs/assets/architecture-light.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 500" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" role="img" aria-label="Architecture: an AI brain on one machine talks to a robot body on another over HTTP.">
+  <defs>
+    <style>
+      .name { font-family: ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, monospace; font-size: 13px; fill: #ffffff; }
+      .role { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 11px; fill: #ffffff; opacity: .82; }
+      .title { font-size: 22px; font-weight: 700; fill: #1f2328; }
+      .sub { font-size: 14px; fill: #57606a; }
+      .cap { font-size: 13px; fill: #57606a; }
+      .hdr { font-size: 15px; font-weight: 700; letter-spacing: .08em; }
+      .pill { font-size: 13px; font-weight: 600; fill: #1f2328; }
+    </style>
+    <marker id="al" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M8 0.5 L1 4.5 L8 8.5 Z" fill="#6e7781"/></marker>
+    <marker id="ar" markerWidth="9" markerHeight="9" refX="2" refY="4.5" orient="auto"><path d="M1 0.5 L8 4.5 L1 8.5 Z" fill="#6e7781"/></marker>
+  </defs>
+
+  <text x="450" y="38" text-anchor="middle" class="title">One framework, split over the network</text>
+  <text x="450" y="60" text-anchor="middle" class="sub">The brain thinks. The body moves. HTTP is the whole contract between them.</text>
+
+  <!-- BRAIN panel -->
+  <rect x="40" y="86" width="352" height="250" rx="14" fill="#eef4ff" stroke="#2563eb" stroke-width="2"/>
+  <circle cx="66" cy="114" r="6" fill="#2563eb"/>
+  <text x="82" y="119" class="hdr" fill="#1d4ed8">BRAIN</text>
+  <text x="352" y="119" text-anchor="end" class="sub" font-size="12">Pi 5 / desktop / cloud</text>
+
+  <g>
+    <rect x="58" y="134" width="316" height="42" rx="8" fill="#2563eb"/>
+    <text x="72" y="160" class="name">nox_voice_brain.py</text><text x="360" y="160" text-anchor="end" class="role">LLM reasoning</text>
+    <rect x="58" y="184" width="316" height="42" rx="8" fill="#2563eb"/>
+    <text x="72" y="210" class="name">nox_body_client.py</text><text x="360" y="210" text-anchor="end" class="role">→ body API</text>
+    <rect x="58" y="234" width="316" height="42" rx="8" fill="#2563eb"/>
+    <text x="72" y="260" class="name">nox_voice_relay.py</text><text x="360" y="260" text-anchor="end" class="role">3-tier voice</text>
+    <rect x="58" y="284" width="316" height="42" rx="8" fill="#2563eb" opacity=".72"/>
+    <text x="72" y="310" class="name">telegram_bot.py</text><text x="360" y="310" text-anchor="end" class="role">remote · opt</text>
+  </g>
+
+  <!-- BODY panel -->
+  <rect x="508" y="86" width="352" height="360" rx="14" fill="#fdeff2" stroke="#c51a4a" stroke-width="2"/>
+  <circle cx="534" cy="114" r="6" fill="#c51a4a"/>
+  <text x="550" y="119" class="hdr" fill="#a10f33">BODY</text>
+  <text x="844" y="119" text-anchor="end" class="sub" font-size="12">Pi 4 / the robot</text>
+
+  <g>
+    <rect x="526" y="134" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="160" class="name">nox_brain_bridge.py</text><text x="828" y="160" text-anchor="end" class="role">HTTP :8888</text>
+    <rect x="526" y="184" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="210" class="name">nox_daemon.py</text><text x="828" y="210" text-anchor="end" class="role">servos · TCP :9999</text>
+    <rect x="526" y="234" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="260" class="name">nox_behavior_engine.py</text><text x="828" y="260" text-anchor="end" class="role">FSM · patrol</text>
+    <rect x="526" y="284" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="310" class="name">nox_vision.py</text><text x="828" y="310" text-anchor="end" class="role">SmolVLM</text>
+    <rect x="526" y="334" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="360" class="name">nox_face_recognition.py</text><text x="828" y="360" text-anchor="end" class="role">SCRFD+ArcFace</text>
+    <rect x="526" y="384" width="316" height="42" rx="8" fill="#c51a4a"/>
+    <text x="540" y="410" class="name">nox_voice_loop_v3.py</text><text x="828" y="410" text-anchor="end" class="role">STT</text>
+  </g>
+
+  <!-- link spine -->
+  <line x1="398" y1="196" x2="502" y2="196" stroke="#6e7781" stroke-width="2" marker-end="url(#al)"/>
+  <line x1="502" y1="230" x2="398" y2="230" stroke="#6e7781" stroke-width="2" marker-end="url(#ar)"/>
+  <rect x="406" y="174" width="88" height="22" rx="11" fill="#ffffff" stroke="#6e7781"/>
+  <text x="450" y="189" text-anchor="middle" class="pill">HTTP :8888</text>
+  <rect x="404" y="230" width="92" height="22" rx="11" fill="#ffffff" stroke="#6e7781"/>
+  <text x="450" y="245" text-anchor="middle" class="pill" font-size="12">callback :8889</text>
+
+  <text x="450" y="478" text-anchor="middle" class="cap">Any LLM · any network · any robot — implement one adapter and you're in.</text>
+</svg>

--- a/docs/media-guide.md
+++ b/docs/media-guide.md
@@ -1,0 +1,78 @@
+# Media capture guide
+
+Everything the README needs, and exactly how to make it. The architecture
+diagram is already in the repo (`docs/assets/architecture-*.svg`, generated, no
+capture needed). The three items below need the real robot — capture them once,
+drop the files in `docs/assets/`, and uncomment the matching block in the README
+(each drop-in point is marked with an `HTML comment` there).
+
+Keep files small — a README that takes 10 s to load costs you the stars the
+visuals were meant to win. Target: hero GIF < 5 MB, screenshot < 400 KB.
+
+---
+
+## 1. Hero GIF → `docs/assets/hero.gif`
+
+The single most important asset. It should answer "what is this?" in five
+seconds, before anyone reads a word.
+
+**Shot list (5–8 s, no cuts):** PiDog standing → a spoken command lands
+("Nox, sit!") → the dog sits and wags its tail. One continuous take, eye-level,
+the whole dog in frame, plain background, good light.
+
+**Record** on a phone (1080p is plenty), then convert — the two-pass palette
+route keeps it sharp and small:
+
+```bash
+# trim to the good 6 seconds first (adjust -ss start / -t duration)
+ffmpeg -ss 0 -t 6 -i raw.mov -vf "fps=15,scale=640:-1:flags=lanczos,palettegen" palette.png
+ffmpeg -ss 0 -t 6 -i raw.mov -i palette.png -vf "fps=15,scale=640:-1:flags=lanczos,paletteuse" hero.gif
+```
+
+If it's still over ~5 MB, drop `fps` to 12 or `scale` to 480.
+
+---
+
+## 2. Demo video → YouTube (thumbnail `docs/assets/demo-thumb.jpg`)
+
+30–60 s, hosted on YouTube (GitHub won't embed a video file inline — a linked
+thumbnail is the standard pattern, already wired in the README).
+
+**Shot list:** voice command → movement · autonomous patrol avoiding an obstacle
+· a face being recognized (name overlay). Narrate or add captions so it reads
+without sound.
+
+Grab a thumbnail frame from the video:
+
+```bash
+ffmpeg -ss 3 -i demo.mp4 -vframes 1 -q:v 3 docs/assets/demo-thumb.jpg
+```
+
+Then set the real video id in the README (`https://youtu.be/YOUR_VIDEO_ID`).
+
+---
+
+## 3. Telegram control screenshot → `docs/assets/telegram-control.png`
+
+Shows the "control your robot from your phone" angle — high-signal, takes two
+minutes.
+
+**What to capture:** a real Telegram exchange with the bot — you send a command
+("sit and wag"), the dog's photo or a status reply comes back. Crop to the
+conversation. **Scrub anything private** before committing: your phone number,
+the bot token, other chats, real names in the header.
+
+```bash
+# optional: shrink/optimise a PNG screenshot
+ffmpeg -i telegram-raw.png -vf "scale=360:-1" docs/assets/telegram-control.png
+```
+
+---
+
+## Checklist before committing
+
+- [ ] `hero.gif` under ~5 MB, plays in a loop, dog fully in frame
+- [ ] `demo-thumb.jpg` set + real YouTube id in the README
+- [ ] `telegram-control.png` — no phone number, token, or private chats visible
+- [ ] uncomment the matching README blocks (hero, "See It in Action")
+- [ ] check both light and dark GitHub themes render the page cleanly


### PR DESCRIPTION
Addresses #3 (README has zero visuals) by shipping the highest-leverage piece that needs **no hardware** now, and making the rest drop-in.

**Ships now:**
- A theme-aware **architecture SVG** (light + dark via `<picture>`) of the Brain/Body-over-HTTP split — the project's actual differentiator. Wired into the Architecture section; the ASCII version kept in a `<details>` so it stays text-searchable.

**Staged for capture (needs the robot):**
- Ready-to-uncomment README slots for the **hero GIF**, **demo video**, and **Telegram screenshot**, placed at the exact right spots — nothing broken renders on the live page until the files exist.
- `docs/media-guide.md`: shot list + `ffmpeg` commands + a pre-commit checklist (incl. scrubbing the Telegram token/number) so each asset is a drop-in.

**Verified:** both SVGs are well-formed XML and render cleanly (checked light + dark); all live README references resolve; HTML comment / `<picture>` / `<details>` tags balanced; the three hardware assets stay commented out.

Diagram preview (light):

![architecture](docs/assets/architecture-light.svg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)