### PR TITLE
fix: make every silent failure on the sit/battery path loud (issue #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ curl -X POST http://your-robot.local:8888/voice/input \
 curl http://your-robot.local:8888/photo -o snap.jpg
 ```
 
+> **Shell quoting matters:** wrap the JSON in **single quotes** and use
+> **double quotes** inside it, exactly as above. With the quotes swapped the
+> shell mangles the JSON before curl ever sends it — the bridge then answers
+> HTTP 400 with what it actually received, so you can see the mangling.
+
 ## 📡 API Reference
 
 ### Bridge Endpoints (Body — Port 8888)

--- a/body/nox_brain_bridge.py
+++ b/body/nox_brain_bridge.py
@@ -356,7 +356,15 @@ class BridgeHandler(BaseHTTPRequestHandler):
         length = int(self.headers.get("Content-Length", 0))
         if length > 0:
             body = self.rfile.read(length)
-            return json.loads(body)
+            try:
+                return json.loads(body)
+            except json.JSONDecodeError as e:
+                # Broken shell quoting is the #1 cause here (issue #12): the
+                # handler must answer loudly, not crash with an empty reply.
+                return {
+                    "_json_error": str(e),
+                    "_raw": body[:120].decode("utf-8", errors="replace"),
+                }
         return {}
     
     def do_OPTIONS(self):
@@ -567,7 +575,17 @@ class BridgeHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         path = self.path.split("?")[0]
         body = self._read_json()
-        
+        if "_json_error" in body:
+            self._send_json({
+                "ok": False,
+                "error": f"request body is not valid JSON: {body['_json_error']}",
+                "received": body["_raw"],
+                "hint": "quote with single quotes OUTSIDE, double quotes INSIDE: "
+                        "curl -X POST http://<host>:8888/action "
+                        "-H 'Content-Type: application/json' -d '{\"action\": \"sit\"}'",
+            }, 400)
+            return
+
         if path == "/action":
             # Execute body action(s). Accept both {"actions": [...]} (array) and
             # the singular {"action": "sit"} — the latter is what people reach for

--- a/body/nox_daemon.py
+++ b/body/nox_daemon.py
@@ -243,8 +243,11 @@ def cmd_status():
     try:
         with dog_lock:
             info["battery_v"] = round(dog.get_battery_voltage(), 2)
-    except:
+    except Exception as e:
+        # Keep "error" for compatibility, but expose WHY it failed: a working
+        # battery with a failing ADC read looks identical otherwise (issue #12).
         info["battery_v"] = "error"
+        info["battery_error"] = f"{type(e).__name__}: {e}"
     return info
 
 
@@ -822,6 +825,10 @@ def handle_client(conn):
                 request = {"cmd": cmd_name}
 
         cmd_name = request.get("cmd", request.get("command", ""))
+        # Log external commands so `journalctl -u nox-body` shows what arrived.
+        # "status" is polled continuously by the bridge and would drown the log.
+        if cmd_name != "status" and not request.get("_internal"):
+            print(f"[nox] cmd: {json.dumps(request)[:200]}", flush=True)
         if cmd_name in COMMANDS:
             result = COMMANDS[cmd_name](request)
             response = json.dumps(result)

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -103,11 +103,26 @@ if [[ $IS_BODY -eq 1 ]]; then
     if [[ -n "$status_json" ]]; then
       pass "bridge answers on :${BRIDGE_PORT}/status"
       if printf '%s' "$status_json" | grep -q '"battery_v": *"error"'; then
-        warn "battery_v is \"error\" — the robot can't read its battery"
-        hint "servos are powered by the 2-cell battery, NOT USB-C: charge it,"
-        hint "plug it in, switch it on — otherwise actions return ok but the dog won't move"
+        berr="$(printf '%s' "$status_json" | sed -n 's/.*"battery_error": *"\([^"]*\)".*/\1/p')"
+        warn "battery_v is \"error\" — the daemon can't READ the battery voltage${berr:+ (${berr})}"
+        hint "if the dog also won't move: check the 2-cell battery — servos run on it, NOT USB-C"
+        hint "if the dog moves fine, only the ADC read fails; test it directly:"
+        hint "  python3 -c 'from robot_hat import utils; print(utils.get_battery_voltage())'"
+        [[ -z "$berr" ]] && hint "no battery_error detail — update + restart: git pull && sudo systemctl restart nox-body"
       elif printf '%s' "$status_json" | grep -qE '"battery_v": *[0-9]'; then
         pass "battery voltage readable ($(printf '%s' "$status_json" | grep -oE '"battery_v": *[0-9.]+' | head -1 | grep -oE '[0-9.]+')V)"
+      fi
+
+      # Is the RUNNING bridge process on current code? An empty /action POST
+      # must error loudly (issue #13); a silent ok means the service was never
+      # restarted after git pull. Harmless probe: no action is ever executed.
+      action_probe="$(curl -s --max-time 5 -X POST "http://127.0.0.1:${BRIDGE_PORT}/action" \
+        -H 'Content-Type: application/json' -d '{}' 2>/dev/null)"
+      if printf '%s' "$action_probe" | grep -q 'no action given'; then
+        pass "running bridge is on current code (/action errors loudly on empty input)"
+      elif printf '%s' "$action_probe" | grep -q '"ok": *true'; then
+        fail "running bridge is on OUTDATED code — /action still swallows empty input silently"
+        hint "cd $REPO_DIR && git pull && sudo systemctl restart nox-bridge nox-body"
       fi
     else
       fail "no response from bridge on :${BRIDGE_PORT}"

--- a/tests/test_bridge_api.py
+++ b/tests/test_bridge_api.py
@@ -1,0 +1,68 @@
+"""Live tests for the bridge HTTP handler — no hardware needed.
+
+The bridge talks to the daemon over TCP, so the handler itself can run
+anywhere. These tests pin the loud-failure behavior from issues #12/#13:
+broken JSON and empty input must produce actionable errors, never a silent ok.
+"""
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+
+import body.nox_brain_bridge as bridge
+
+
+@pytest.fixture(scope="module")
+def server_port():
+    srv = bridge.ThreadedHTTPServer(("127.0.0.1", 0), bridge.BridgeHandler)
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    yield port
+    srv.shutdown()
+
+
+def post(port, path, data):
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=data.encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        r = urllib.request.urlopen(req, timeout=10)
+        return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+def test_broken_json_is_loud_400(server_port):
+    # Swapped shell quotes mangle the JSON exactly like this (issue #12).
+    code, body = post(server_port, "/action", "{action: sit}")
+    assert code == 400
+    assert not body["ok"]
+    assert "not valid JSON" in body["error"]
+    assert body["received"] == "{action: sit}"
+    assert "single quotes OUTSIDE" in body["hint"]
+
+
+def test_empty_action_is_loud(server_port):
+    code, body = post(server_port, "/action", "{}")
+    assert not body["ok"]
+    assert body["error"] == "no action given"
+    assert "valid_actions" in body
+
+
+def test_singular_action_is_forwarded(server_port):
+    # No daemon is running in CI: the action must still be forwarded and the
+    # connection error surfaced per-result — not swallowed.
+    code, body = post(server_port, "/action", '{"action": "sit"}')
+    assert len(body["results"]) == 1
+    assert not body["ok"]  # daemon unreachable -> error propagates
+
+
+def test_array_actions_forwarded_per_item(server_port):
+    code, body = post(server_port, "/action", '{"actions": ["sit", "wag_tail"]}')
+    assert len(body["results"]) == 2


### PR DESCRIPTION
## Why

Thio007's dog still doesn't sit (#12), and every failure mode on that path was silent — undebuggable remotely:

1. **Broken JSON crashed the bridge handler.** Swapped shell quotes mangle the JSON; `_read_json()` raised uncaught → curl saw an empty reply, no error anywhere. This is very likely what happened to his 'one word or two' attempts, matching his `'` vs `"` question.
2. **Battery read failures were reduced to `battery_v: "error"`.** His standalone test proves the battery powers the servos fine — so the ADC *read* fails, but the bare `except:` hid the actual exception.
3. **The daemon never logged incoming commands** — `journalctl -u nox-body` could not show whether a command even arrived.
4. **doctor.sh couldn't detect a service running outdated code** — after `git pull` without a service restart, everything looks current on disk while the old bug keeps running.

## What

- bridge `_read_json`/`do_POST`: invalid JSON → **HTTP 400** echoing what was received + a copy-paste quoting hint (applies to all POST endpoints)
- daemon `/status`: adds `battery_error` with `ExceptionType: message` next to `battery_v: "error"`
- daemon: logs each external command (status polls + internal calls excluded, so the journal stays readable)
- doctor.sh: battery hint now distinguishes *dead battery* vs *failed read* (with the error text + a direct-read one-liner), and a new live probe POSTs `{}` to `/action` — a silent `ok` flags **running outdated code** with the exact fix command
- README: shell-quoting note next to the curl examples
- tests: `tests/test_bridge_api.py` spins up the real handler (no hardware needed) and pins the loud-failure contract — broken JSON, empty input, singular + array forwarding

## Verification

- `PYTHONPATH=. pytest tests/` → 10 passed (4 new)
- live-tested the handler: broken JSON → 400 with hint; `{}` → 'no action given'; `{"action": "sit"}` → forwarded, daemon-unreachable error surfaced per-result
- `ruff` clean on all new code; `bash -n` + smoke run of doctor.sh on a non-robot machine degrades gracefully

#12 stays open until Thio007 confirms on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
