### PR TITLE
fix: battery ADC fallback + preset-action routing + doctor false alarms (issue #12)

### DIFF
--- a/body/nox_daemon.py
+++ b/body/nox_daemon.py
@@ -98,6 +98,11 @@ _pidog_mod.Pidog.__init__ = _patched_init
 
 from pidog import Pidog
 
+try:
+    from pidog import preset_actions as _preset_actions
+except Exception:
+    _preset_actions = None
+
 # ─── Global state ───
 dog = None
 camera_lock = threading.Lock()
@@ -234,6 +239,26 @@ def init_dog():
     print("[nox] PiDog ready. Nox lebt! ⚡", flush=True)
 
 
+_battery_adc = None
+
+def read_battery_voltage():
+    """Battery voltage with fallback around a broken SDK path.
+
+    robot_hat 2.5.2a1 ships a get_battery_voltage() that raises
+    NameError: '_adc_obj' is not defined (issue #12). The measurement itself
+    works — battery sits on ADC channel A4 behind a 1:3 divider — so on any
+    SDK failure we read the ADC directly. Caller must hold dog_lock.
+    """
+    global _battery_adc
+    try:
+        return round(dog.get_battery_voltage(), 2)
+    except Exception:
+        from robot_hat import ADC
+        if _battery_adc is None:
+            _battery_adc = ADC("A4")
+        return round(_battery_adc.read_voltage() * 3, 2)
+
+
 def cmd_status():
     """System status."""
     import shutil
@@ -242,7 +267,7 @@ def cmd_status():
     info["disk_free_gb"] = round(free / (1024**3), 1)
     try:
         with dog_lock:
-            info["battery_v"] = round(dog.get_battery_voltage(), 2)
+            info["battery_v"] = read_battery_voltage()
     except Exception as e:
         # Keep "error" for compatibility, but expose WHY it failed: a working
         # battery with a failing ADC read looks identical otherwise (issue #12).
@@ -258,9 +283,40 @@ def cmd_move(action, steps=3, speed=80, internal=False):
         # Re-init servos before moving
         pass  # PiDog re-enables on do_action
     with dog_lock:
-        dog.do_action(action, step_count=int(steps), speed=int(speed))
-        time.sleep(1.5)
-    return {"ok": True, "action": action}
+        # SDK do_action() swallows unknown actions (prints and returns), so we
+        # must route ourselves. Probe the CLASS for a property: instance
+        # hasattr would execute the ActionDict property just to probe it.
+        if isinstance(getattr(type(dog.actions_dict), action, None), property):
+            dog.do_action(action, step_count=int(steps), speed=int(speed))
+            time.sleep(1.5)
+            return {"ok": True, "action": action}
+        # pant/bark/howling & friends live in pidog.preset_actions, not in
+        # ActionDict (issue #12: 'ActionDict' object has no attribute 'pant').
+        preset = getattr(_preset_actions, action, None) if _preset_actions else None
+        if callable(preset):
+            try:
+                preset(dog)
+                return {"ok": True, "action": action, "via": "preset"}
+            except Exception as e:
+                return {"ok": False, "action": action,
+                        "error": f"preset action failed: {type(e).__name__}: {e}"}
+        return {"ok": False, "action": action,
+                "error": f"action '{action}' not supported by this pidog SDK",
+                "supported": _supported_actions()}
+
+
+def _supported_actions():
+    """Everything cmd_move can execute: ActionDict properties + preset functions."""
+    dict_actions = [n for n, v in vars(type(dog.actions_dict)).items()
+                    if isinstance(v, property)]
+    preset_fns = []
+    if _preset_actions:
+        preset_fns = [n for n in dir(_preset_actions)
+                      if not n.startswith("_")
+                      and callable(getattr(_preset_actions, n))
+                      and getattr(getattr(_preset_actions, n), "__module__", "")
+                      == _preset_actions.__name__]
+    return sorted(set(dict_actions + preset_fns))
 
 
 def cmd_head(yaw=0, roll=0, pitch=0, smooth=True, internal=False):
@@ -526,7 +582,7 @@ def cmd_sensors():
     # Battery
     try:
         with dog_lock:
-            v = dog.get_battery_voltage()
+            v = read_battery_voltage()
             result["battery_v"] = round(v, 2)
             result["battery_pct"] = max(0, min(100, round((v - 6.0) / (8.4 - 6.0) * 100)))
             result["charging"] = v > 8.35
@@ -608,7 +664,7 @@ def cmd_body_state():
             result["posture"] = "unknown"
         
         try:
-            v = dog.get_battery_voltage()
+            v = read_battery_voltage()
             result["battery_v"] = round(v, 2)
             result["battery_pct"] = max(0, min(100, round((v - 6.0) / (8.4 - 6.0) * 100)))
             result["charging"] = v > 8.35

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -95,13 +95,38 @@ if [[ $IS_BODY -eq 1 ]]; then
   section "Body — services"
   check_service nox-body
   check_service nox-bridge
-  check_service nox-voice
+  # nox-voice exits cleanly when no Vosk model is installed — in that case
+  # "not running" is the documented behavior, not a failure.
+  vosk_model_dir="${VOSK_MODEL_PATH:-$HOME/vosk-models/vosk-model-small-de-0.15}"
+  if [[ ! -f /etc/systemd/system/nox-voice.service ]]; then
+    warn "nox-voice is not installed"
+    hint "run: sudo ./scripts/install-body.sh (body) or install-brain.sh (brain)"
+  elif svc_active nox-voice; then
+    pass "nox-voice is running"
+  elif [[ ! -d "$vosk_model_dir" ]]; then
+    warn "nox-voice not running — expected without a Vosk model (voice input stays off)"
+  else
+    fail "nox-voice is installed but not running"
+    hint "sudo systemctl restart nox-voice && journalctl -u nox-voice -n 30 --no-pager"
+  fi
 
   section "Body — bridge API"
   if have curl; then
-    status_json="$(curl -s --max-time 5 "http://127.0.0.1:${BRIDGE_PORT}/status" 2>/dev/null)"
+    # The bridge needs a few seconds after a restart (camera init etc.) —
+    # retry before declaring it down, or doctor right after systemctl restart
+    # reports a false FAIL (seen in issue #12).
+    status_json=""; bridge_tries=1
+    for bridge_tries in 1 2 3 4 5; do
+      status_json="$(curl -s --max-time 5 "http://127.0.0.1:${BRIDGE_PORT}/status" 2>/dev/null)"
+      [[ -n "$status_json" ]] && break
+      sleep 2
+    done
     if [[ -n "$status_json" ]]; then
-      pass "bridge answers on :${BRIDGE_PORT}/status"
+      if [[ $bridge_tries -gt 1 ]]; then
+        pass "bridge answers on :${BRIDGE_PORT}/status (took ${bridge_tries} tries — it was still starting up)"
+      else
+        pass "bridge answers on :${BRIDGE_PORT}/status"
+      fi
       if printf '%s' "$status_json" | grep -q '"battery_v": *"error"'; then
         berr="$(printf '%s' "$status_json" | sed -n 's/.*"battery_error": *"\([^"]*\)".*/\1/p')"
         warn "battery_v is \"error\" — the daemon can't READ the battery voltage${berr:+ (${berr})}"


### PR DESCRIPTION
## Why

Thio007's first full diagnostic run (#12) — enabled by the loud-failure work in #16 — exposed three concrete, fixable problems:

1. **Battery: upstream bug in robot_hat 2.5.2a1.** `/status` finally showed the real error: `NameError: name '_adc_obj' is not defined`. The SDK's `get_battery_voltage()` crashes before touching hardware. The measurement itself is trivially available: ADC channel A4 behind a 1:3 divider.
2. **`pant`/`bark`/`howling` were never real actions.** They are `preset_actions` *functions* in the SDK, not `ActionDict` entries. `do_action()` swallowed them with a printed error while we returned `ok:true` — the `'ActionDict' object has no attribute 'pant'` journal spam (every ~20s from the behavior engine's "excited" state) came from this.
3. **doctor.sh false alarms.** Running doctor immediately after `systemctl restart` hit the bridge mid-startup (camera init takes seconds) → false "no response on :8888" FAIL, seconds before a manual curl succeeded. And nox-voice being inactive without a Vosk model is documented behavior, yet doctor called it FAIL.

## What

- `read_battery_voltage()`: tries the SDK first, falls back to a direct `ADC("A4").read_voltage() * 3`; used at all three battery read sites (`/status`, `cmd_sensors`, state block)
- `cmd_move` routing: ActionDict **property** probe (on the class — instance `hasattr` would execute the property) → `do_action`; else preset function → called directly; else **loud error** listing every action this SDK build actually supports (`_supported_actions()`: ActionDict properties + module-own preset functions). Bonus: preset gems like `hand_shake`, `high_five`, `stretch`, `attack_posture` become reachable.
- doctor.sh: `/status` probe retries up to 5×/2s and reports when the bridge was still starting; nox-voice inactive without Vosk model → WARN with explanation instead of FAIL

## Verification

- `PYTHONPATH=. pytest tests/` → 10 passed
- routing logic verified against a faithful mock of pidog 1.3.11 (`ActionDict` property probe, preset fallback, dict-method `keys` correctly rejected, supported-list excludes imported helpers)
- `bash -n` on doctor.sh; ruff clean on new code

#12 stays open until Thio007 confirms on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
