### PR TITLE
feat: servo self-test + dead-action-thread detection (issue #12)

### DIFF
--- a/body/nox_brain_bridge.py
+++ b/body/nox_brain_bridge.py
@@ -477,6 +477,12 @@ class BridgeHandler(BaseHTTPRequestHandler):
             r = send_to_daemon({"cmd": "scan_sweep"})
             self._send_json(r)
 
+        elif path == "/selftest":
+            # Servo self-test (issue #12): direct synchronous servo write that
+            # bypasses the SDK action threads, plus thread/buffer health.
+            # CAUTION: physically moves the dog (sit -> stand).
+            self._send_json(send_to_daemon({"cmd": "servo_test"}, timeout=15))
+
         elif path == "/sensors":
             # Aggregated sensor data (Sprint 4)
             raw = send_to_daemon({"cmd": "sensors"})
@@ -556,7 +562,7 @@ class BridgeHandler(BaseHTTPRequestHandler):
                     "GET": ["/status", "/perception", "/photo", "/look", "/faces",
                             "/voice/inbox", "/voice/echo_until", "/memory/recent",
                             "/memory/stats", "/state", "/scan", "/scan/sweep",
-                            "/sensors", "/capabilities", "/vision"],
+                            "/sensors", "/capabilities", "/vision", "/selftest"],
                     "POST": ["/action", "/speak", "/command", "/rgb", "/head",
                              "/face/register", "/voice/respond", "/voice/input",
                              "/combo", "/behavior/start", "/behavior/stop",

--- a/body/nox_daemon.py
+++ b/body/nox_daemon.py
@@ -236,6 +236,12 @@ def init_dog():
         _hw_status.append("ears:ok")
     print(f"[nox] Hardware: {', '.join(_hw_status)}", flush=True)
     print(f"[nox] Audio device: {_PLAYBACK_DEVICE}", flush=True)
+    dead = _dead_action_threads()
+    if dead:
+        print(f"[nox] WARNING: action thread(s) already dead after init: "
+              f"{', '.join(dead)} — the dog will NOT move!", flush=True)
+    else:
+        print("[nox] Action threads healthy (legs/head/tail consumers running)", flush=True)
     print("[nox] PiDog ready. Nox lebt! ⚡", flush=True)
 
 
@@ -289,7 +295,22 @@ def cmd_move(action, steps=3, speed=80, internal=False):
         if isinstance(getattr(type(dog.actions_dict), action, None), property):
             dog.do_action(action, step_count=int(steps), speed=int(speed))
             time.sleep(1.5)
-            return {"ok": True, "action": action}
+            # The SDK's consumer threads die permanently on their first
+            # exception (`except Exception: break`) — after that every action
+            # queues forever while do_action still "succeeds" (issue #12:
+            # ok:true but the dog never moves). Detect that here.
+            dead = _dead_action_threads()
+            if dead:
+                return {"ok": False, "action": action,
+                        "error": f"action thread(s) dead: {', '.join(dead)} — "
+                                 "commands queue but are never executed",
+                        "hint": "sudo systemctl restart nox-body; then check: "
+                                "journalctl -u nox-body | grep -i exception"}
+            queued = _action_buffer_depth()
+            result = {"ok": True, "action": action}
+            if queued > 0:
+                result["note"] = f"{queued} motion frames still queued (long action or slow servos)"
+            return result
         # pant/bark/howling & friends live in pidog.preset_actions, not in
         # ActionDict (issue #12: 'ActionDict' object has no attribute 'pant').
         preset = getattr(_preset_actions, action, None) if _preset_actions else None
@@ -303,6 +324,50 @@ def cmd_move(action, steps=3, speed=80, internal=False):
         return {"ok": False, "action": action,
                 "error": f"action '{action}' not supported by this pidog SDK",
                 "supported": _supported_actions()}
+
+
+def _dead_action_threads():
+    """Names of SDK action-consumer threads that have died. Empty = healthy."""
+    dead = []
+    for name in ("legs_thread", "head_thread", "tail_thread"):
+        t = getattr(dog, name, None)
+        if t is not None and not t.is_alive():
+            dead.append(name)
+    return dead
+
+
+def _action_buffer_depth():
+    """Total motion frames waiting in the SDK's action buffers."""
+    total = 0
+    for name in ("legs_action_buffer", "head_action_buffer", "tail_action_buffer"):
+        buf = getattr(dog, name, None)
+        if buf is not None:
+            total += len(buf)
+    return total
+
+
+def cmd_servo_test():
+    """Split issue #12 in half: write servo angles DIRECTLY and synchronously,
+    bypassing the SDK's buffer/thread machinery. If the dog moves here but not
+    via /action, the consumer threads are the problem; if it doesn't move
+    here either, the failure is below the SDK (robot_hat / MCU / power).
+    """
+    report = {"threads_dead": _dead_action_threads(),
+              "buffered_frames": _action_buffer_depth()}
+    with dog_lock:
+        try:
+            frames, part = dog.actions_dict["sit"]
+            report["direct_write"] = "sit pose, final frame, via legs.servo_move"
+            dog.legs.servo_move(list(frames[-1]), 60)
+            time.sleep(1.0)
+            frames, part = dog.actions_dict["stand"]
+            dog.legs.servo_move(list(frames[-1]), 60)
+            report["ok"] = True
+            report["question"] = "did the dog visibly sit and stand back up?"
+        except Exception as e:
+            report["ok"] = False
+            report["direct_write_error"] = f"{type(e).__name__}: {e}"
+    return report
 
 
 def _supported_actions():
@@ -815,6 +880,7 @@ def cmd_three_way_scan():
 # ─── Command dispatcher ───
 COMMANDS = {
     "status": lambda args: cmd_status(),
+    "servo_test": lambda args: cmd_servo_test(),
     "move": lambda args: cmd_move(args.get("action", "stand"), args.get("steps", 3), args.get("speed", 80), internal=args.get("_internal", False)),
     "head": lambda args: cmd_head(args.get("yaw", 0), args.get("roll", 0), args.get("pitch", 0), args.get("smooth", True), internal=args.get("_internal", False)),
     "head_ema": lambda args: cmd_head_ema(args.get("yaw", 0), args.get("roll", 0), args.get("pitch", 0), internal=args.get("_internal", False)),


### PR DESCRIPTION
## Why

New data point from #12: the dog **does not move** in Nox mode even though the journal proves the command arrived and `do_action` ran without error — while SunFounder examples move it fully. So the loss happens between our `do_action` call and the servos, on the same SDK stack.

Two facts make this diabolical:
1. The SDK's action-consumer threads (`_legs_action_thread` etc.) **die permanently on their first exception** (`except Exception: break`). After that, every `do_action` buffers frames forever and still *looks* successful.
2. Servos are the only subsystem driven through the HAT's PWM path — touch, RGB, IMU, ultrasonic all ride other paths. Everything can look healthy while movement is dead.

This can't be diagnosed further by remote reasoning — so instrument it and split the problem in half.

## What

- **`cmd_move`**: after each action, checks whether legs/head/tail consumer threads are alive — dead threads now return a loud error (with journal-grep hint) instead of `ok:true`; otherwise reports undrained buffer depth as a note
- **`servo_test` daemon command + bridge `GET /selftest`**: writes the sit and stand poses **directly and synchronously** via `legs.servo_move`, bypassing the buffer/thread machinery, and reports thread/buffer health. Outcome tells us the layer: moves here but not via `/action` → SDK thread problem; doesn't move here either → robot_hat/MCU/servo-power level
- **init logging**: action-thread health is printed right after startup, so a thread that dies during init is visible in the journal immediately
- `/selftest` added to `/capabilities`

## Verification

- `PYTHONPATH=. pytest tests/` → 10 passed
- `py_compile` + ruff clean on changed code
- Physical outcome must come from Thio007's robot — instructions posted on #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
